### PR TITLE
Show credit hours in specialization section headers

### DIFF
--- a/src/ArtificialIntelligencePlanner.js
+++ b/src/ArtificialIntelligencePlanner.js
@@ -28,7 +28,7 @@ const electivesPartTwo = [
 function ArtificialIntelligencePlanner({ courses, addToCourseList, selectedCourses }) {
   return (
     <div>
-      <h2>Core Courses</h2>
+      <h2>Core Courses (9 hours)</h2>
       <h5>Note: Any core courses in excess of the 9 hour requirement may be used as electives.</h5>
       <h3>Pick one (1) of:</h3>
       <BasicTable 
@@ -46,7 +46,7 @@ function ArtificialIntelligencePlanner({ courses, addToCourseList, selectedCours
         selectedCourses={ selectedCourses }
       />
       <h5 className="count">Picked {selectedCourses.filter(course => coreCoursesPartTwo.includes(course.name)).length}</h5>
-      <h2>Electives</h2>
+      <h2>Electives (6 hours)</h2>
       <h3>Pick two (2) courses from the two (2) sections below:</h3>
       <h4>AI Methods:</h4>
       <BasicTable
@@ -64,7 +64,7 @@ function ArtificialIntelligencePlanner({ courses, addToCourseList, selectedCours
         selectedCourses={ selectedCourses }
       />
       <h5 className="count">Picked {selectedCourses.filter(course => electivesPartTwo.includes(course.name)).length}</h5>
-      <h2>Free Electives</h2>
+      <h2>Free Electives (15 hours)</h2>
       <h3>Pick five (5) free electives.</h3>
       <h4>Free electives may be any courses offered through the OMSCS program. If you take extra specialization core courses and/or extra specialization elective courses beyond what is required in your chosen specialization, the extra course(s) can be used only towards the "free" electives.</h4>
       <BasicTable 

--- a/src/ComputationalPerceptionRoboticsPlanner.js
+++ b/src/ComputationalPerceptionRoboticsPlanner.js
@@ -23,7 +23,7 @@ const electivesPartTwo = [
 function ComputationalPerceptionRoboticsPlanner({ courses, addToCourseList, selectedCourses }) {
   return (
     <div>
-      <h2>Core Courses</h2>
+      <h2>Core Courses (6 hours)</h2>
       <h3>Pick one (1) of:</h3>
       <BasicTable 
         rows={ courses.filter(course => coreCoursesPartOne.includes(course.name)) }
@@ -40,7 +40,7 @@ function ComputationalPerceptionRoboticsPlanner({ courses, addToCourseList, sele
         selectedCourses={ selectedCourses }
       />
       <h5 className="count">Picked {selectedCourses.filter(course => coreCoursesPartTwo.includes(course.name)).length}</h5>
-      <h2>Electives</h2>
+      <h2>Electives (9 hours)</h2>
       <h3>Pick three (3) courses from Perception and Robotics, with at least one (1) course from each:</h3>
       <h4>Perception</h4>
       <BasicTable 
@@ -58,7 +58,7 @@ function ComputationalPerceptionRoboticsPlanner({ courses, addToCourseList, sele
         selectedCourses={ selectedCourses }
       />
       <h5 className="count">Picked {selectedCourses.filter(course => electivesPartTwo.includes(course.name)).length}</h5>
-      <h2>Free Electives</h2>
+      <h2>Free Electives (15 hours)</h2>
       <h3>Pick five (5) free electives.</h3>
       <h4>Free electives may be any courses offered through the OMSCS program. If you take extra specialization core courses and/or extra specialization elective courses beyond what is required in your chosen specialization, the extra course(s) can be used only towards the "free" electives.</h4>
       <BasicTable 

--- a/src/ComputerGraphicsPlanner.js
+++ b/src/ComputerGraphicsPlanner.js
@@ -24,7 +24,7 @@ const electives = [
 function ComputerGraphicsPlanner({ courses, addToCourseList, selectedCourses }) {
   return (
     <div>
-      <h2>Core Courses</h2>
+      <h2>Core Courses (6 hours)</h2>
       <h3>Pick one (1) of: </h3>
       <BasicTable 
         rows={ courses.filter(course => coreCoursesPartOne.includes(course.name)) }
@@ -41,7 +41,7 @@ function ComputerGraphicsPlanner({ courses, addToCourseList, selectedCourses }) 
         selectedCourses={ selectedCourses }
       />
       <h4 className="count">Picked {selectedCourses.filter(course => coreCoursesPartTwo.includes(course.name)).length}</h4>
-      <h2>Electives</h2>
+      <h2>Electives (9 hours)</h2>
       <h3>Pick three (3) of: </h3>
       <BasicTable 
         rows={ courses.filter(course => electives.includes(course.name)) }
@@ -50,7 +50,7 @@ function ComputerGraphicsPlanner({ courses, addToCourseList, selectedCourses }) 
         selectedCourses={ selectedCourses }
       />
       <h4 className="count">Picked {selectedCourses.filter(course => electives.includes(course.name)).length}</h4>
-      <h2>Free Electives</h2>
+      <h2>Free Electives (15 hours)</h2>
       <h3>Pick five (5) of:</h3>
       <BasicTable 
         rows={ courses.filter(course => freeElectives.includes(course.name) && !coreCoursesPartOne.concat(coreCoursesPartTwo).concat(electives).includes(course.name)) }

--- a/src/ComputingSystemsPlanner.js
+++ b/src/ComputingSystemsPlanner.js
@@ -39,7 +39,7 @@ const electives = [
 function ComputingSystemsPlanner({ courses, addToCourseList, selectedCourses }) {
   return (
     <div>
-      <h2>Core Courses</h2>
+      <h2>Core Courses (9 hours)</h2>
       <h5>Note: Any Core Courses in excess of the 9 hour (3 class) requirement may be used as Computing Systems Electives.</h5>
       <h3>Pick two (2) of:</h3>
       <BasicTable 
@@ -57,7 +57,7 @@ function ComputingSystemsPlanner({ courses, addToCourseList, selectedCourses }) 
         selectedCourses={ selectedCourses }
       />
       <h4 className="count">Picked {selectedCourses.filter(course => coreCoursesPartTwo.includes(course.name)).length}</h4>
-      <h2>Electives</h2>
+      <h2>Electives (9 hours)</h2>
       <h3>Pick three (3) of:</h3>
       <BasicTable 
         rows={ courses.filter(course => electives.includes(course.name)) }
@@ -66,7 +66,7 @@ function ComputingSystemsPlanner({ courses, addToCourseList, selectedCourses }) 
         selectedCourses={ selectedCourses }
       />
       <h4 className="count">Picked {selectedCourses.filter(course => electives.includes(course.name)).length}</h4>
-      <h2>Free Electives</h2>
+      <h2>Free Electives (12 hours)</h2>
       <h3>Pick four (4) free electives.</h3>
       <h4>Free electives may be any courses offered through the OMSCS program. If you take extra specialization core courses and/or extra specialization elective courses beyond what is required in your chosen specialization, the extra course(s) can be used only towards the "free" electives.</h4>
       <BasicTable 

--- a/src/HCIPlanner.js
+++ b/src/HCIPlanner.js
@@ -21,7 +21,7 @@ const electivesPartTwo = [
 function HCIPlanner({ courses, addToCourseList, selectedCourses }) {
   return (
     <div>
-      <h2>Core Courses</h2>
+      <h2>Core Courses (6 hours)</h2>
       <h3>Pick two (2) of:</h3>
       <BasicTable 
         rows={ courses.filter(course => coreCourses.includes(course.name)) }
@@ -30,7 +30,7 @@ function HCIPlanner({ courses, addToCourseList, selectedCourses }) {
         selectedCourses={ selectedCourses }
       />
       <h5 className="count">Picked {selectedCourses.filter(course => coreCourses.includes(course.name)).length}</h5>
-      <h2>Electives</h2>
+      <h2>Electives (9 hours)</h2>
       <h3>Pick three (3) courses from the two sub-areas below, including at least one from each sub-area:</h3>
       <h4>Sub-area: Design and evaluation concepts</h4>
       <BasicTable 
@@ -48,7 +48,7 @@ function HCIPlanner({ courses, addToCourseList, selectedCourses }) {
         selectedCourses={ selectedCourses }
       />
       <h5 className="count">Picked {selectedCourses.filter(course => electivesPartTwo.includes(course.name)).length}</h5>
-      <h2>Free Electives</h2>
+      <h2>Free Electives (15 hours)</h2>
       <h3>Pick five (5) free electives.</h3>
       <h4>Free electives may be any courses offered through the OMSCS program. If you take extra specialization core courses and/or extra specialization elective courses beyond what is required in your chosen specialization, the extra course(s) can be used only towards the "free" electives.</h4>
       <BasicTable 

--- a/src/MachineLearningPlanner.js
+++ b/src/MachineLearningPlanner.js
@@ -27,7 +27,7 @@ const electives = [
 function MachineLearningPlanner({ courses, addToCourseList, selectedCourses }) {
   return (
     <div>
-      <h2>Core Courses</h2>
+      <h2>Core Courses (6 hours)</h2>
       <h3>Pick one (1) of:</h3>
       <BasicTable 
         rows={ courses.filter(course => coreCoursesPartOne.includes(course.name)) }
@@ -44,7 +44,7 @@ function MachineLearningPlanner({ courses, addToCourseList, selectedCourses }) {
         selectedCourses={ selectedCourses }
       />
       <h5 className="count">Picked {selectedCourses.filter(course => coreCoursesPartTwo.includes(course.name)).length}</h5>
-      <h2>Electives</h2>
+      <h2>Electives (9 hours)</h2>
       <h3>Pick three (3) of:</h3>
       <BasicTable 
         rows={ courses.filter(course => electives.includes(course.name)) }
@@ -53,7 +53,7 @@ function MachineLearningPlanner({ courses, addToCourseList, selectedCourses }) {
         selectedCourses={ selectedCourses }
       />
       <h5 className="count">Picked {selectedCourses.filter(course => electives.includes(course.name)).length}</h5>
-      <h2>Free Electives</h2>
+      <h2>Free Electives (15 hours)</h2>
       <h3>Pick five (5) free electives.</h3>
       <h4>Free electives may be any courses offered through the OMSCS program. If you take extra specialization core courses and/or extra specialization elective courses beyond what is required in your chosen specialization, the extra course(s) can be used only towards the "free" electives.</h4>
       <BasicTable 


### PR DESCRIPTION
Adds the credit-hour tally next to each section header, matching the official GT specialization pages — e.g. "Core Courses (9 hours)", "Electives (6 hours)", "Free Electives (15 hours)" for AI. This makes it unambiguous how many classes each section requires.

Hours per specialization (from omscs.gatech.edu):

| Specialization | Core | Electives | Free Electives |
|---|---|---|---|
| Artificial Intelligence | 9 | 6 | 15 |
| Machine Learning | 6 | 9 | 15 |
| Computational Perception & Robotics | 6 | 9 | 15 |
| Human-Computer Interaction | 6 | 9 | 15 |
| Computing Systems | 9 | 9 | 12 |
| Computer Graphics | 6 | 9 | 15 |

Verified all six specializations render the correct tallies in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)