### PR TITLE
Accessibility quick fixes from axe audit

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -20,7 +20,7 @@
   font-weight: 700;
   cursor: pointer;
   padding: 0.5rem 0;
-  color: var(--color-primary);
+  color: var(--color-primary-text);
   list-style: none;
   display: flex;
   align-items: center;

--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,7 @@ function App() {
   return (
     <div className="App">
       <Header />
-      <div className="App-body">
+      <main className="App-body">
         <details className="section-intro">
           <summary>Program Info & Degree Requirements</summary>
           <h2>Overview</h2>
@@ -40,7 +40,7 @@ function App() {
 
         </details>
         <Planner />
-      </div>
+      </main>
     </div>
   );
 }

--- a/src/ArtificialIntelligencePlanner.js
+++ b/src/ArtificialIntelligencePlanner.js
@@ -29,7 +29,7 @@ function ArtificialIntelligencePlanner({ courses, addToCourseList, selectedCours
   return (
     <div>
       <h2>Core Courses (9 hours)</h2>
-      <h5>Note: Any core courses in excess of the 9 hour requirement may be used as electives.</h5>
+      <p className="note">Note: Any core courses in excess of the 9 hour requirement may be used as electives.</p>
       <h3>Pick one (1) of:</h3>
       <BasicTable 
         rows={ courses.filter(course => coreCoursesPartOne.includes(course.name)) }
@@ -37,7 +37,7 @@ function ArtificialIntelligencePlanner({ courses, addToCourseList, selectedCours
         showCheckbox
         selectedCourses={ selectedCourses }
       />
-      <h5 className="count">Picked {selectedCourses.filter(course => coreCoursesPartOne.includes(course.name)).length}</h5>
+      <p className="count">Picked {selectedCourses.filter(course => coreCoursesPartOne.includes(course.name)).length}</p>
       <h3>Pick two (2) of:</h3>
       <BasicTable 
         rows={ courses.filter(course => coreCoursesPartTwo.includes(course.name)) }
@@ -45,7 +45,7 @@ function ArtificialIntelligencePlanner({ courses, addToCourseList, selectedCours
         showCheckbox
         selectedCourses={ selectedCourses }
       />
-      <h5 className="count">Picked {selectedCourses.filter(course => coreCoursesPartTwo.includes(course.name)).length}</h5>
+      <p className="count">Picked {selectedCourses.filter(course => coreCoursesPartTwo.includes(course.name)).length}</p>
       <h2>Electives (6 hours)</h2>
       <h3>Pick two (2) courses from the two (2) sections below:</h3>
       <h4>AI Methods:</h4>
@@ -55,7 +55,7 @@ function ArtificialIntelligencePlanner({ courses, addToCourseList, selectedCours
         showCheckbox
         selectedCourses={ selectedCourses }
       />
-      <h5 className="count">Picked {selectedCourses.filter(course => electivesPartOne.includes(course.name)).length}</h5>
+      <p className="count">Picked {selectedCourses.filter(course => electivesPartOne.includes(course.name)).length}</p>
       <h4>Cognition, Ethics, and Human-Centered AI:</h4>
       <BasicTable
         rows={ courses.filter(course => electivesPartTwo.includes(course.name)) }
@@ -63,7 +63,7 @@ function ArtificialIntelligencePlanner({ courses, addToCourseList, selectedCours
         showCheckbox
         selectedCourses={ selectedCourses }
       />
-      <h5 className="count">Picked {selectedCourses.filter(course => electivesPartTwo.includes(course.name)).length}</h5>
+      <p className="count">Picked {selectedCourses.filter(course => electivesPartTwo.includes(course.name)).length}</p>
       <h2>Free Electives (15 hours)</h2>
       <h3>Pick five (5) free electives.</h3>
       <h4>Free electives may be any courses offered through the OMSCS program. If you take extra specialization core courses and/or extra specialization elective courses beyond what is required in your chosen specialization, the extra course(s) can be used only towards the "free" electives.</h4>
@@ -73,7 +73,7 @@ function ArtificialIntelligencePlanner({ courses, addToCourseList, selectedCours
         showCheckbox
         selectedCourses={ selectedCourses }
       />
-      <h5 className="count">Picked {selectedCourses.filter(course => freeElectives.includes(course.name) && !coreCoursesPartOne.concat(coreCoursesPartTwo).concat(electivesPartOne).concat(electivesPartTwo).includes(course.name)).length}</h5>
+      <p className="count">Picked {selectedCourses.filter(course => freeElectives.includes(course.name) && !coreCoursesPartOne.concat(coreCoursesPartTwo).concat(electivesPartOne).concat(electivesPartTwo).includes(course.name)).length}</p>
     </div>
   );
 }

--- a/src/BasicTable.js
+++ b/src/BasicTable.js
@@ -149,7 +149,7 @@ function BasicTable({ tableId, rows, addToCourseList, showCheckbox, showIndex = 
                     <td>
                       <div>{ name }</div>
                       <div>
-                        <a href={officialURL} target="_blank" rel="noreferrer">GT Official</a> - {slug ? <a href={"https://www.omscentral.com/courses/" + slug + "/reviews"} target="_blank" rel="noreferrer">Reviews</a> : "No review page yet"}
+                        <a href={officialURL} target="_blank" rel="noreferrer" aria-label={`${name} on the official GT site`}>GT Official</a> - {slug ? <a href={"https://www.omscentral.com/courses/" + slug + "/reviews"} target="_blank" rel="noreferrer" aria-label={`${name} reviews on OMSCentral`}>Reviews</a> : "No review page yet"}
                       </div>
                     </td>
                     <td>{ formatNumber(rating) }</td>

--- a/src/ComputationalPerceptionRoboticsPlanner.js
+++ b/src/ComputationalPerceptionRoboticsPlanner.js
@@ -31,7 +31,7 @@ function ComputationalPerceptionRoboticsPlanner({ courses, addToCourseList, sele
         showCheckbox
         selectedCourses={ selectedCourses }
       />
-      <h4 className="count">Picked {selectedCourses.filter(course => coreCoursesPartOne.includes(course.name)).length}</h4>
+      <p className="count">Picked {selectedCourses.filter(course => coreCoursesPartOne.includes(course.name)).length}</p>
       <h3>Pick one (1) of:</h3>
       <BasicTable 
         rows={ courses.filter(course => coreCoursesPartTwo.includes(course.name)) }
@@ -39,7 +39,7 @@ function ComputationalPerceptionRoboticsPlanner({ courses, addToCourseList, sele
         showCheckbox
         selectedCourses={ selectedCourses }
       />
-      <h5 className="count">Picked {selectedCourses.filter(course => coreCoursesPartTwo.includes(course.name)).length}</h5>
+      <p className="count">Picked {selectedCourses.filter(course => coreCoursesPartTwo.includes(course.name)).length}</p>
       <h2>Electives (9 hours)</h2>
       <h3>Pick three (3) courses from Perception and Robotics, with at least one (1) course from each:</h3>
       <h4>Perception</h4>
@@ -49,7 +49,7 @@ function ComputationalPerceptionRoboticsPlanner({ courses, addToCourseList, sele
         showCheckbox
         selectedCourses={ selectedCourses }
       />
-      <h5 className="count">Picked {selectedCourses.filter(course => electivesPartOne.includes(course.name)).length}</h5>
+      <p className="count">Picked {selectedCourses.filter(course => electivesPartOne.includes(course.name)).length}</p>
       <h4>Robotics</h4>
       <BasicTable 
         rows={ courses.filter(course => electivesPartTwo.includes(course.name)) }
@@ -57,7 +57,7 @@ function ComputationalPerceptionRoboticsPlanner({ courses, addToCourseList, sele
         showCheckbox
         selectedCourses={ selectedCourses }
       />
-      <h5 className="count">Picked {selectedCourses.filter(course => electivesPartTwo.includes(course.name)).length}</h5>
+      <p className="count">Picked {selectedCourses.filter(course => electivesPartTwo.includes(course.name)).length}</p>
       <h2>Free Electives (15 hours)</h2>
       <h3>Pick five (5) free electives.</h3>
       <h4>Free electives may be any courses offered through the OMSCS program. If you take extra specialization core courses and/or extra specialization elective courses beyond what is required in your chosen specialization, the extra course(s) can be used only towards the "free" electives.</h4>
@@ -67,7 +67,7 @@ function ComputationalPerceptionRoboticsPlanner({ courses, addToCourseList, sele
         showCheckbox
         selectedCourses={ selectedCourses }
       />
-      <h5 className="count">Picked {selectedCourses.filter(course => freeElectives.includes(course.name) && !coreCoursesPartOne.concat(coreCoursesPartTwo).concat(electivesPartOne).concat(electivesPartTwo).includes(course.name)).length}</h5>
+      <p className="count">Picked {selectedCourses.filter(course => freeElectives.includes(course.name) && !coreCoursesPartOne.concat(coreCoursesPartTwo).concat(electivesPartOne).concat(electivesPartTwo).includes(course.name)).length}</p>
     </div>
   );
 }

--- a/src/ComputerGraphicsPlanner.js
+++ b/src/ComputerGraphicsPlanner.js
@@ -32,7 +32,7 @@ function ComputerGraphicsPlanner({ courses, addToCourseList, selectedCourses }) 
         showCheckbox
         selectedCourses={ selectedCourses }
       />
-      <h4 className="count">Picked {selectedCourses.filter(course => coreCoursesPartOne.includes(course.name)).length}</h4>
+      <p className="count">Picked {selectedCourses.filter(course => coreCoursesPartOne.includes(course.name)).length}</p>
       <h3>Pick one (1) of: </h3>
       <BasicTable 
         rows={ courses.filter(course => coreCoursesPartTwo.includes(course.name)) }
@@ -40,7 +40,7 @@ function ComputerGraphicsPlanner({ courses, addToCourseList, selectedCourses }) 
         showCheckbox
         selectedCourses={ selectedCourses }
       />
-      <h4 className="count">Picked {selectedCourses.filter(course => coreCoursesPartTwo.includes(course.name)).length}</h4>
+      <p className="count">Picked {selectedCourses.filter(course => coreCoursesPartTwo.includes(course.name)).length}</p>
       <h2>Electives (9 hours)</h2>
       <h3>Pick three (3) of: </h3>
       <BasicTable 
@@ -49,7 +49,7 @@ function ComputerGraphicsPlanner({ courses, addToCourseList, selectedCourses }) 
         showCheckbox
         selectedCourses={ selectedCourses }
       />
-      <h4 className="count">Picked {selectedCourses.filter(course => electives.includes(course.name)).length}</h4>
+      <p className="count">Picked {selectedCourses.filter(course => electives.includes(course.name)).length}</p>
       <h2>Free Electives (15 hours)</h2>
       <h3>Pick five (5) of:</h3>
       <BasicTable 
@@ -58,7 +58,7 @@ function ComputerGraphicsPlanner({ courses, addToCourseList, selectedCourses }) 
         showCheckbox
         selectedCourses={ selectedCourses }
       />
-      <h5 className="count">Picked {selectedCourses.filter(course => freeElectives.includes(course.name) && !coreCoursesPartOne.concat(coreCoursesPartTwo).concat(electives).includes(course.name)).length}</h5>
+      <p className="count">Picked {selectedCourses.filter(course => freeElectives.includes(course.name) && !coreCoursesPartOne.concat(coreCoursesPartTwo).concat(electives).includes(course.name)).length}</p>
     </div>
   );
 }

--- a/src/ComputingSystemsPlanner.js
+++ b/src/ComputingSystemsPlanner.js
@@ -40,7 +40,7 @@ function ComputingSystemsPlanner({ courses, addToCourseList, selectedCourses }) 
   return (
     <div>
       <h2>Core Courses (9 hours)</h2>
-      <h5>Note: Any Core Courses in excess of the 9 hour (3 class) requirement may be used as Computing Systems Electives.</h5>
+      <p className="note">Note: Any Core Courses in excess of the 9 hour (3 class) requirement may be used as Computing Systems Electives.</p>
       <h3>Pick two (2) of:</h3>
       <BasicTable 
         rows={ courses.filter(course => coreCoursesPartOne.includes(course.name)) }
@@ -48,7 +48,7 @@ function ComputingSystemsPlanner({ courses, addToCourseList, selectedCourses }) 
         showCheckbox
         selectedCourses={ selectedCourses }
       />
-      <h4 className="count">Picked {selectedCourses.filter(course => coreCoursesPartOne.includes(course.name)).length}</h4>
+      <p className="count">Picked {selectedCourses.filter(course => coreCoursesPartOne.includes(course.name)).length}</p>
       <h3>Pick one (1) of:</h3>
       <BasicTable 
         rows={ courses.filter(course => coreCoursesPartTwo.includes(course.name)) }
@@ -56,7 +56,7 @@ function ComputingSystemsPlanner({ courses, addToCourseList, selectedCourses }) 
         showCheckbox
         selectedCourses={ selectedCourses }
       />
-      <h4 className="count">Picked {selectedCourses.filter(course => coreCoursesPartTwo.includes(course.name)).length}</h4>
+      <p className="count">Picked {selectedCourses.filter(course => coreCoursesPartTwo.includes(course.name)).length}</p>
       <h2>Electives (9 hours)</h2>
       <h3>Pick three (3) of:</h3>
       <BasicTable 
@@ -65,7 +65,7 @@ function ComputingSystemsPlanner({ courses, addToCourseList, selectedCourses }) 
         showCheckbox
         selectedCourses={ selectedCourses }
       />
-      <h4 className="count">Picked {selectedCourses.filter(course => electives.includes(course.name)).length}</h4>
+      <p className="count">Picked {selectedCourses.filter(course => electives.includes(course.name)).length}</p>
       <h2>Free Electives (12 hours)</h2>
       <h3>Pick four (4) free electives.</h3>
       <h4>Free electives may be any courses offered through the OMSCS program. If you take extra specialization core courses and/or extra specialization elective courses beyond what is required in your chosen specialization, the extra course(s) can be used only towards the "free" electives.</h4>
@@ -75,7 +75,7 @@ function ComputingSystemsPlanner({ courses, addToCourseList, selectedCourses }) 
         showCheckbox
         selectedCourses={ selectedCourses }
       />
-      <h4 className="count">Picked {selectedCourses.filter(course => freeElectives.includes(course.name) && !coreCoursesPartOne.concat(coreCoursesPartTwo).concat(electives).includes(course.name)).length}</h4>
+      <p className="count">Picked {selectedCourses.filter(course => freeElectives.includes(course.name) && !coreCoursesPartOne.concat(coreCoursesPartTwo).concat(electives).includes(course.name)).length}</p>
     </div>
   );
 }

--- a/src/HCIPlanner.js
+++ b/src/HCIPlanner.js
@@ -29,7 +29,7 @@ function HCIPlanner({ courses, addToCourseList, selectedCourses }) {
         showCheckbox
         selectedCourses={ selectedCourses }
       />
-      <h5 className="count">Picked {selectedCourses.filter(course => coreCourses.includes(course.name)).length}</h5>
+      <p className="count">Picked {selectedCourses.filter(course => coreCourses.includes(course.name)).length}</p>
       <h2>Electives (9 hours)</h2>
       <h3>Pick three (3) courses from the two sub-areas below, including at least one from each sub-area:</h3>
       <h4>Sub-area: Design and evaluation concepts</h4>
@@ -39,7 +39,7 @@ function HCIPlanner({ courses, addToCourseList, selectedCourses }) {
         showCheckbox
         selectedCourses={ selectedCourses }
       />
-      <h5 className="count">Picked {selectedCourses.filter(course => electivesPartOne.includes(course.name)).length}</h5>
+      <p className="count">Picked {selectedCourses.filter(course => electivesPartOne.includes(course.name)).length}</p>
       <h4>Sub-area: Interactive technology</h4>
       <BasicTable 
         rows={ courses.filter(course => electivesPartTwo.includes(course.name)) }
@@ -47,7 +47,7 @@ function HCIPlanner({ courses, addToCourseList, selectedCourses }) {
         showCheckbox
         selectedCourses={ selectedCourses }
       />
-      <h5 className="count">Picked {selectedCourses.filter(course => electivesPartTwo.includes(course.name)).length}</h5>
+      <p className="count">Picked {selectedCourses.filter(course => electivesPartTwo.includes(course.name)).length}</p>
       <h2>Free Electives (15 hours)</h2>
       <h3>Pick five (5) free electives.</h3>
       <h4>Free electives may be any courses offered through the OMSCS program. If you take extra specialization core courses and/or extra specialization elective courses beyond what is required in your chosen specialization, the extra course(s) can be used only towards the "free" electives.</h4>
@@ -57,7 +57,7 @@ function HCIPlanner({ courses, addToCourseList, selectedCourses }) {
         showCheckbox
         selectedCourses={ selectedCourses }
       />
-      <h5 className="count">Picked {selectedCourses.filter(course => freeElectives.includes(course.name) && !coreCourses.concat(electivesPartOne).concat(electivesPartTwo).includes(course.name)).length}</h5>
+      <p className="count">Picked {selectedCourses.filter(course => freeElectives.includes(course.name) && !coreCourses.concat(electivesPartOne).concat(electivesPartTwo).includes(course.name)).length}</p>
     </div>
   );
 }

--- a/src/Header.js
+++ b/src/Header.js
@@ -4,7 +4,7 @@ import GithubIcon from "./assets/github-mark.png";
 
 export default function Header() {
   return (
-    <div className='Header'>
+    <header className='Header'>
         <h1>OMSCS Course Planner</h1>
         <div className="actions">
           <Button 
@@ -37,6 +37,6 @@ export default function Header() {
             <img className="github" src={ GithubIcon } alt="Github"/>
           </a>
         </div>
-    </div>
+    </header>
   );
 }

--- a/src/MachineLearningPlanner.js
+++ b/src/MachineLearningPlanner.js
@@ -35,7 +35,7 @@ function MachineLearningPlanner({ courses, addToCourseList, selectedCourses }) {
         showCheckbox
         selectedCourses={ selectedCourses }
       />
-      <h5 className="count">Picked {selectedCourses.filter(course => coreCoursesPartOne.includes(course.name)).length}</h5>
+      <p className="count">Picked {selectedCourses.filter(course => coreCoursesPartOne.includes(course.name)).length}</p>
       <h3>Pick one (1) of:</h3>
       <BasicTable 
         rows={ courses.filter(course => coreCoursesPartTwo.includes(course.name)) }
@@ -43,9 +43,9 @@ function MachineLearningPlanner({ courses, addToCourseList, selectedCourses }) {
         showCheckbox
         selectedCourses={ selectedCourses }
       />
-      <h5 className="count">Picked {selectedCourses.filter(course => coreCoursesPartTwo.includes(course.name)).length}</h5>
+      <p className="count">Picked {selectedCourses.filter(course => coreCoursesPartTwo.includes(course.name)).length}</p>
       <h2>Electives (9 hours)</h2>
-      <h5>Note: Elective ML courses must have at least 1/3 of their graded content based on Machine Learning.</h5>
+      <p className="note">Note: Elective ML courses must have at least 1/3 of their graded content based on Machine Learning.</p>
       <h3>Pick three (3) of:</h3>
       <BasicTable 
         rows={ courses.filter(course => electives.includes(course.name)) }
@@ -53,7 +53,7 @@ function MachineLearningPlanner({ courses, addToCourseList, selectedCourses }) {
         showCheckbox
         selectedCourses={ selectedCourses }
       />
-      <h5 className="count">Picked {selectedCourses.filter(course => electives.includes(course.name)).length}</h5>
+      <p className="count">Picked {selectedCourses.filter(course => electives.includes(course.name)).length}</p>
       <h2>Free Electives (15 hours)</h2>
       <h3>Pick five (5) free electives.</h3>
       <h4>Free electives may be any courses offered through the OMSCS program. If you take extra specialization core courses and/or extra specialization elective courses beyond what is required in your chosen specialization, the extra course(s) can be used only towards the "free" electives.</h4>
@@ -63,7 +63,7 @@ function MachineLearningPlanner({ courses, addToCourseList, selectedCourses }) {
         showCheckbox
         selectedCourses={ selectedCourses }
       />
-      <h5 className="count">Picked {selectedCourses.filter(course => freeElectives.includes(course.name) && !coreCoursesPartOne.concat(coreCoursesPartTwo).concat(electives).includes(course.name)).length}</h5>
+      <p className="count">Picked {selectedCourses.filter(course => freeElectives.includes(course.name) && !coreCoursesPartOne.concat(coreCoursesPartTwo).concat(electives).includes(course.name)).length}</p>
     </div>
   );
 }

--- a/src/Planner.css
+++ b/src/Planner.css
@@ -81,11 +81,13 @@
 }
 
 /* Notes */
-.section-plan h5 {
+.section-plan h5,
+.section-plan .note {
     font-size: 0.9rem;
     font-weight: 400;
     color: var(--color-text-tertiary);
     font-style: italic;
+    margin: 0.5rem 0;
 }
 
 .Planner .count {
@@ -93,6 +95,7 @@
     font-weight: 600;
     font-size: 1rem !important;
     font-style: normal !important;
+    margin: 0.5rem 0;
 }
 
 .Planner .footer-buttons {
@@ -139,7 +142,7 @@
     font-family: 'Montserrat', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif !important;
     font-weight: 700;
     font-size: 1rem;
-    color: var(--color-primary);
+    color: var(--color-primary-text);
 }
 
 .sticky-counter-text.requirement-met {

--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,8 @@
   --color-primary: #6366F1;
   --color-primary-hover: #4F46E5;
   --color-primary-subtle: #EEF2FF;
+  /* darker shade for text on white — meets WCAG AA 4.5:1 */
+  --color-primary-text: #4F46E5;
 
   /* Accent */
   --color-accent: #F59E0B;
@@ -27,11 +29,11 @@
   --color-text-on-primary: #FFFFFF;
 
   /* Semantic — Status */
-  --color-success: #16A34A;
+  --color-success: #15803D;
   --color-success-bg: #F0FDF4;
   --color-warning: #F59E0B;
   --color-warning-bg: #FFFBEB;
-  --color-danger: #EF4444;
+  --color-danger: #DC2626;
   --color-danger-bg: #FEF2F2;
 
 }


### PR DESCRIPTION
High-level accessibility pass with axe-core; fixes the four violation classes found:

- **Color contrast (serious)**: darkened `--color-success` (#16A34A → #15803D) and `--color-danger` (#EF4444 → #DC2626), and added `--color-primary-text` (#4F46E5) for indigo text on white (summary toggle, sticky counter). All text now meets WCAG AA 4.5:1; same hue families, so the visual change is subtle. Button/background uses of the original tokens are untouched.
- **Landmarks**: page content is now in `<main>`, page header is a `<header>` element.
- **Heading order**: "Picked N" counters and section notes were h4/h5 elements that skipped heading levels; they're now `<p>` with the same styling (they were never real headings).
- **Link names**: every course row repeated identical "GT Official" / "Reviews" link text; each now has an aria-label naming the course, so screen-reader link lists are navigable.

Already good and untouched: checkbox aria-labels, select aria-label, image alt text, html lang.

axe-core 4.10 reports **zero violations** after the change (landing page + specialization selected). Production build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)