### PR TITLE
Steer course availability to OMSHub; flag omscs.rocks as unmaintained

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -32,18 +32,29 @@
 }
 
 .section-intro summary::before {
-  content: '\25B6';
-  font-size: 0.75rem;
-  transition: transform 0.2s ease;
-  display: inline-block;
+  content: '';
+  box-sizing: border-box;
+  width: 0.7rem;
+  height: 0.7rem;
+  border-top: 3px solid var(--color-primary-text);
+  border-right: 3px solid var(--color-primary-text);
+  border-radius: 1px;
+  transform: rotate(45deg);
+  transition: transform 0.2s ease, border-color 0.2s ease;
+  flex-shrink: 0;
+  margin-right: 0.25rem;
 }
 
 .section-intro[open] summary::before {
-  transform: rotate(90deg);
+  transform: rotate(135deg);
 }
 
 .section-intro summary:hover {
   color: var(--color-primary-hover);
+}
+
+.section-intro summary:hover::before {
+  border-color: var(--color-primary-hover);
 }
 
 @media only screen and (max-width: 600px) {

--- a/src/App.js
+++ b/src/App.js
@@ -16,8 +16,7 @@ function App() {
           <h2>Important Resources</h2>
           <ul>
             <li><a href="https://omscs.gatech.edu/orientation-documents" target="_blank" rel="noreferrer">Orientation document</a> - Most up-to-date program information</li>
-            <li><a href="https://docs.google.com/spreadsheets/d/e/2PACX-1vRyHrRhH2V52bsYFEtm-8oJDaFOlyGYz6AKXm8WwsthN3fNP3KGkEx7O7D9ZHV3j2iKnzU2XHqoh4pQ/pubhtml" target="_blank" rel="noreferrer">Course availability</a></li>
-            <li><a href="https://really.omscs.rocks/" target="_blank" rel="noreferrer">Course availability with frozen headers</a></li>
+            <li><a href="https://www.omshub.org/schedule" target="_blank" rel="noreferrer">Course availability (OMSHub schedule)</a> - Recommended; <a href="https://docs.google.com/spreadsheets/d/e/2PACX-1vRyHrRhH2V52bsYFEtm-8oJDaFOlyGYz6AKXm8WwsthN3fNP3KGkEx7O7D9ZHV3j2iKnzU2XHqoh4pQ/pubhtml" target="_blank" rel="noreferrer">omscs.rocks</a> is no longer maintained</li>
             <li><a href="https://registrar.gatech.edu/current-students/calendars" target="_blank" rel="noreferrer">Academic calendar</a></li>
             <li>The degree worksheets <a href="https://www.cc.gatech.edu/graduate-forms-procedures" target="_blank" rel="noreferrer">here</a> and <a href="https://degreeaudit.gatech.edu/" target="_blank" rel="noreferrer">here</a></li>
           </ul>

--- a/src/Planner.js
+++ b/src/Planner.js
@@ -175,7 +175,7 @@ function Planner() {
           <BasicTable tableId="chosenCourses" rows={chosenCourseList} initiallySorted={false} showIndex={ true } />
         </Tab>
       </Tabs>
-      { chosenCourseList.length !== 0 && <h4>Check <a href="https://docs.google.com/spreadsheets/d/e/2PACX-1vRyHrRhH2V52bsYFEtm-8oJDaFOlyGYz6AKXm8WwsthN3fNP3KGkEx7O7D9ZHV3j2iKnzU2XHqoh4pQ/pubhtml" target="_blank" rel="noreferrer">omscs.rocks</a> for course availability.</h4>}
+      { chosenCourseList.length !== 0 && <h4>Check <a href="https://www.omshub.org/schedule" target="_blank" rel="noreferrer">OMSHub's schedule</a> for course availability. (<a href="https://docs.google.com/spreadsheets/d/e/2PACX-1vRyHrRhH2V52bsYFEtm-8oJDaFOlyGYz6AKXm8WwsthN3fNP3KGkEx7O7D9ZHV3j2iKnzU2XHqoh4pQ/pubhtml" target="_blank" rel="noreferrer">omscs.rocks</a> is no longer maintained.)</h4>}
 
       {chosenCourseList.length > 0 && <Stats selectedCourses={chosenCourseList} />}
       {chosenCourseList.length > 0 && <CourseScatterPlot allCourses={reviews.filter(c => freeElectives.includes(c.name))} selectedCourses={chosenCourseList} />}


### PR DESCRIPTION
## What

omscs.rocks is [no longer being updated](https://www.reddit.com/r/OMSCS/comments/1skbwli/will_there_be_a_replacement_for_omscsrocks/), so this points users to [OMSHub's schedule](https://www.omshub.org/schedule) for course availability instead.

### Changes
- **Important Resources** list: replaced the two stale availability links (Google sheet + `really.omscs.rocks`) with a single recommended OMSHub link, noting omscs.rocks is no longer maintained.
- **Callout under the chosen course plan**: now points to OMSHub's schedule with the same note.
- Both "omscs.rocks" mentions link to the source availability spreadsheet.
- Made the **"Program Info & Degree Requirements"** disclosure caret a larger, vertically-centered purple CSS chevron so it clearly reads as an expandable toggle (the previous faint triangle wasn't obvious).

## Verification

Checked in the dev server: notice and links render correctly, the omscs.rocks link resolves to the spreadsheet URL, no console errors, and the chevron centers with the heading text and rotates on expand/collapse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)