### PR TITLE
Track column sorts and course adds via GA4 custom events

### DIFF
--- a/src/BasicTable.js
+++ b/src/BasicTable.js
@@ -21,30 +21,19 @@ function BasicTable({ tableId = "coursePicker", rows, addToCourseList, showCheck
   }, [rows.length])
 
   const handleHeaderClick = (event) => {
-    const clickedHeader = event.target.childNodes[0]?.textContent.trim();
-    // A click on the arrow span (↑/↓) or the already-sorted header toggles direction
-    // on the current column; otherwise it sorts by the newly clicked column.
-    const isToggle = clickedHeader === currentlySortedBy || ["↑", "↓"].includes(clickedHeader);
-    const column = isToggle ? currentlySortedBy : clickedHeader;
-    const nextDirection = isToggle
-      ? (sortDirection === "ascending" ? "descending" : "ascending")
-      : "ascending";
+    // currentTarget is always the <th>, even if the click landed on the sort
+    // arrow inside it; its first child is the header label text.
+    const column = event.currentTarget.childNodes[0]?.textContent.trim();
 
-    if (isToggle) {
-      setSortDirection(nextDirection)
-    } else {
-      setSortDirection("ascending")
-      setCurrentlySortedBy(clickedHeader)
-    }
+    // Re-clicking the sorted column flips direction; a new column starts ascending.
+    const nextDirection =
+      column === currentlySortedBy && sortDirection === "ascending" ? "descending" : "ascending";
+
+    setCurrentlySortedBy(column);
+    setSortDirection(nextDirection);
 
     // GA4 custom event: which column header users sort by (see public/index.html gtag setup)
-    if (column) {
-      window.gtag?.('event', 'column_sort', {
-        table_id: tableId,
-        column,
-        direction: nextDirection,
-      });
-    }
+    window.gtag?.('event', 'column_sort', { table_id: tableId, column, direction: nextDirection });
   }
 
   const sortCompareFunction = (a, b, propertyName, direction) => {

--- a/src/BasicTable.js
+++ b/src/BasicTable.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import Table from 'react-bootstrap/Table';
 import "./BasicTable.css"
 
-function BasicTable({ tableId, rows, addToCourseList, showCheckbox, showIndex = false, initiallySorted = true, selectedCourses }) {
+function BasicTable({ tableId = "coursePicker", rows, addToCourseList, showCheckbox, showIndex = false, initiallySorted = true, selectedCourses }) {
   const [sortedRows, setSortedRows] = useState(rows)
   const [currentlySortedBy, setCurrentlySortedBy] = useState("")
   const [sortDirection, setSortDirection] = useState("ascending")
@@ -22,11 +22,28 @@ function BasicTable({ tableId, rows, addToCourseList, showCheckbox, showIndex = 
 
   const handleHeaderClick = (event) => {
     const clickedHeader = event.target.childNodes[0]?.textContent.trim();
-    if (clickedHeader === currentlySortedBy || ["↑", "↓"].includes(clickedHeader)) {
-      setSortDirection(sortDirection === "ascending" ? "descending" : "ascending") }
-    else {
+    // A click on the arrow span (↑/↓) or the already-sorted header toggles direction
+    // on the current column; otherwise it sorts by the newly clicked column.
+    const isToggle = clickedHeader === currentlySortedBy || ["↑", "↓"].includes(clickedHeader);
+    const column = isToggle ? currentlySortedBy : clickedHeader;
+    const nextDirection = isToggle
+      ? (sortDirection === "ascending" ? "descending" : "ascending")
+      : "ascending";
+
+    if (isToggle) {
+      setSortDirection(nextDirection)
+    } else {
       setSortDirection("ascending")
       setCurrentlySortedBy(clickedHeader)
+    }
+
+    // GA4 custom event: which column header users sort by (see public/index.html gtag setup)
+    if (column) {
+      window.gtag?.('event', 'column_sort', {
+        table_id: tableId,
+        column,
+        direction: nextDirection,
+      });
     }
   }
 
@@ -132,19 +149,28 @@ function BasicTable({ tableId, rows, addToCourseList, showCheckbox, showIndex = 
                     { showCheckbox && <td>
                       <input type="checkbox" className="course-checkbox"
                         aria-label={`Add ${name} to course list`}
-                        checked={selectedCourses && selectedCourses.find(row => row.id === id)}
-                        onChange={(event) => addToCourseList({ 
-                          id,
-                          slug,
-                          codes,
-                          isFoundational,
-                          name,
-                          officialURL,
-                          rating,
-                          difficulty,
-                          workload,
-                          reviewCount,
-                        })}/>
+                        checked={!!(selectedCourses && selectedCourses.find(row => row.id === id))}
+                        onChange={(event) => {
+                          // GA4 custom event: which courses users add/remove
+                          window.gtag?.('event', 'course_select', {
+                            table_id: tableId,
+                            course: name,
+                            code: codes?.join(', '),
+                            action: event.target.checked ? 'add' : 'remove',
+                          });
+                          addToCourseList({
+                            id,
+                            slug,
+                            codes,
+                            isFoundational,
+                            name,
+                            officialURL,
+                            rating,
+                            difficulty,
+                            workload,
+                            reviewCount,
+                          });
+                        }}/>
                     </td> }
                     <td>
                       <div>{ name }</div>


### PR DESCRIPTION
## What

Wires up GA4 custom events to measure how people use the course tables — so we can see **which columns are actually sorted** before deciding whether to add more (e.g. enrollment/seats), and which courses people pick.

### Changes ([BasicTable.js](src/BasicTable.js))
- **`column_sort`** `{ table_id, column, direction }` — fired from `handleHeaderClick` on every header sort. Resolves the column correctly even when the arrow span is clicked, and reports the resulting direction.
- **`course_select`** `{ table_id, course, code, action: 'add'|'remove' }` — fired from the add-to-plan checkbox.
- Default **`tableId = "coursePicker"`** so all per-section picker tables report a consistent id without editing ~25 call sites; the chosen-plan table keeps `"chosenCourses"`.
- Fixes a **pre-existing** React "changing an uncontrolled input to be controlled" warning by coercing the checkbox `checked` prop to a boolean.

Uses the existing GA4 setup (`gtag` in `public/index.html`, `G-XP1BMGDGWP`) — no new dependency or vendor. Guarded with `window.gtag?.(...)` so it's a no-op if gtag is blocked.

## Follow-up (manual, in GA4 UI)

To break events down by parameter, register `column`, `direction`, `table_id`, `course`, `action` as event-scoped **custom dimensions** (Admin → Custom definitions).

## Verification

Drove the dev server: each sort/add fires exactly **one** event with the correct payload (verified against `window.dataLayer`), direction toggles ascending↔descending across re-renders, and the controlled-input warning no longer fires (0 new warnings after forcing full checkbox remounts). No other console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)